### PR TITLE
Makefile: add `clean`, fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ help:
 
 .PHONY: help Makefile
 
+clean:
+	-rm -rf "$(BUILDDIR)"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/conf.py
+++ b/conf.py
@@ -52,4 +52,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []


### PR DESCRIPTION
I ran across two minor hiccups when building the specification on my local machine for the first time.  This PR fixes both.

1.  There is no `make clean`.  This PR adds a `clean` target to the Makefile for convenience.  I did not try to add one to `make.bat` since I am much rustier on batch-file syntax than on Makefile syntax.
2. When I ran `make html`, I got a warning:

   > copying static files... WARNING: html_static_path entry '/home/cxw/proj/editorconfig-specification/_static' does not exist

   This PR removes the static path from conf.py.  This removes that warning.  Since there are no static files currently, there is no change in functionality.

Thanks for considering this PR!