### PR TITLE
Spec version follows Semantic Versioning 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@ available at https://editorconfig-specification.readthedocs.io/en/latest/ .
 
 ## Build
 
-To build, first install [Sphinx][], and then, in the same directory as this
+To build, first install [Sphinx], and then, in the same directory as this
 file, run
 
     make html
 
 The built HTML files should be in `_build`.
 
+## Making changes
+
+- Alter the content in `index.rst`
+- Update the version and release numbers in `conf.py`
+- Submit a GitHub pull request to the [specification repo].
+
+[specification repo]: https://github.com/editorconfig/specification/
 [Sphinx]: https://www.sphinx-doc.org/en/latest/usage/installation.html

--- a/conf.py
+++ b/conf.py
@@ -18,9 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'EditorConfig Specification'
-copyright = '2019, EditorConfig Team'
+copyright = '2019--2020, EditorConfig Team'
 author = 'EditorConfig Team'
 
+version = '0.14.0'
+release = '0.14.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -1,4 +1,4 @@
-..  Copyright (c) 2019 EditorConfig Team
+..  Copyright (c) 2019--2020 EditorConfig Team
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -25,6 +25,8 @@
 
 EditorConfig Specification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is version |version| of this specification.
 
 .. contents:: Table of Contents
 

--- a/index.rst
+++ b/index.rst
@@ -214,11 +214,15 @@ TODO. For now please read the `Plugin Guidelines`_ on GitHub wiki.
 Versioning
 ==========
 
-*This section applies beginning with v0.13 of this specification.*
+*This section applies beginning with version 0.14.0 of this specification.*
 
 This specification has a version, tagged in the `specification repository`_.
 Each specification version corresponds to the same version in the
 `core-tests repository`_.
+
+The version numbering of the specification follows
+`Semantic Versioning 2.0.0`_ ("SemVer").  The version numbering of
+the `core-tests repository`_ also follows SemVer.
 
 Each EditorConfig core, to pass the core tests, must process version
 numbers given with the ``-b`` switch, and must report version numbers when
@@ -228,7 +232,7 @@ Vimscript core might respond to ``-v`` with:
 
 ::
 
-  EditorConfig Vimscript core v1.0.0 - Specification Version 0.13
+  EditorConfig Vimscript core v1.0.0 - Specification Version 0.14.0
 
 Cores, plugins, or editors supporting EditorConfig have their own version
 numbers.  Those version numbers are independent of the version number of
@@ -238,4 +242,5 @@ this specification.
 .. _Python configparser Library: https://docs.python.org/3/library/configparser.html
 .. _Plugin Guidelines: https://github.com/editorconfig/editorconfig/wiki/Plugin-Guidelines
 .. _plugin-tests repository: https://github.com/editorconfig/editorconfig-plugin-tests
+.. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
 .. _specification repository: https://github.com/editorconfig/specification


### PR DESCRIPTION
Implements https://github.com/editorconfig/editorconfig-vote/issues/12.

Ref.: editorconfig/editorconfig#395

In #17, I didn't realize v0.13 of editorconfig-core-test had already been tagged.  Therefore, I propose bumping the version at line 217 to v0.14.0 and tagging editorconfig-core-test in its current state as 0.14.0.