### PR TITLE
Fix broken link to built version on readthedocs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EditorConfig Specification
 
 This repository hosts the specification of EditorConfig. A built version is
-available at https://editorconfig-specification.readthedocs.io/en/latest/ .
+available at https://editorconfig-specification.readthedocs.io/ .
 
 ## Build
 


### PR DESCRIPTION
Fixes #26 