### PR TITLE
Remove the description of inline comments at all

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,8 +21,8 @@ project = 'EditorConfig Specification'
 copyright = '2019--2020, EditorConfig Team'
 author = 'EditorConfig Team'
 
-version = '0.14.0'
-release = '0.14.0'
+version = '0.15.0'
+release = '0.15.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -73,11 +73,6 @@ irrelevant. Each line must be one of the following:
 
 - Blank: contains only whitespace characters.
 - Comment: starts with a ``;`` or a ``#``.
-   - Inserting an unescaped ``#`` or ``;`` after non-whitespace characters in
-     a line (i.e. inline) is not parsed as a comment, nor as part of
-     the section name, the key pair (see below), or the value it was inserted
-     into. This behavior may change in the future; therefore this kind of
-     insertion is not recommended.
 - Section Header: starts with a ``[`` and ends with a ``]``.
    - May not use any non-whitespace characters outside of the surrounding
      brackets.
@@ -100,6 +95,8 @@ Additionally, EditorConfig defines the following terms:
 - Section Name: the string between the beginning ``[`` and the ending ``]``.
 - Section: the lines starting from a Section Header until the beginning of
   the next Section Header or the end of the file.
+ 
+> The EditorConfig fileformat formerly allowed the use of `;` and `#` to parse the rest of a line as comment. This led to confusion how to handle values containing those characters when implementing a parser. We removed the support of inline comments entirely to make the standard easy to implement and understand. Older EditorConfig parsers may still allow inline comments.
 
 Glob Expressions
 ================

--- a/index.rst
+++ b/index.rst
@@ -96,7 +96,11 @@ Additionally, EditorConfig defines the following terms:
 - Section: the lines starting from a Section Header until the beginning of
   the next Section Header or the end of the file.
  
-> The EditorConfig fileformat formerly allowed the use of `;` and `#` to parse the rest of a line as comment. This led to confusion how to handle values containing those characters when implementing a parser. We removed the support of inline comments entirely to make the standard easy to implement and understand. Older EditorConfig parsers may still allow inline comments.
+ 
+   The EditorConfig file format formerly allowed the use of `;` and `#` after the
+   beginning of the line to mark the rest of a line as comment. This led to
+   confusion how to parse values containing those characters. Old EditorConfig
+   parsers may still allow inline comments.
 
 Glob Expressions
 ================

--- a/index.rst
+++ b/index.rst
@@ -88,15 +88,18 @@ Any line that is not one of the above is invalid.
 
 EditorConfig files should be UTF-8 encoded, with LF or CRLF line separators.
 
-Additionally, EditorConfig defines the following terms:
+Terms
+-----
+
+EditorConfig defines the following terms for parts of an EditorConfig file:
 
 - Preamble: the lines that precedes the first section. The preamble is optional
   and may contain key-value pairs, comments and blank lines.
 - Section Name: the string between the beginning ``[`` and the ending ``]``.
 - Section: the lines starting from a Section Header until the beginning of
   the next Section Header or the end of the file.
- 
- 
+
+
    The EditorConfig file format formerly allowed the use of `;` and `#` after the
    beginning of the line to mark the rest of a line as comment. This led to
    confusion how to parse values containing those characters. Old EditorConfig

--- a/index.rst
+++ b/index.rst
@@ -88,6 +88,30 @@ Any line that is not one of the above is invalid.
 
 EditorConfig files should be UTF-8 encoded, with LF or CRLF line separators.
 
+No inline comments
+------------------
+
+.. versionchanged:: 0.15.0
+
+A ``;`` or ``#`` anywhere other than at the beginning of a line does *not*
+start a comment, but is part of the text of that line.  For example::
+
+  [*.txt]
+  foo = editorconfig ;)
+
+gives variable ``foo`` the value ``editorconfig ;)`` in ``*.txt`` files,
+*not* the value ``editorconfig``.
+
+This specification does not define any "escaping" mechanism for
+``;`` or ``#`` characters.
+
+.. admonition :: Compatibility
+
+  The EditorConfig file format formerly allowed the use of `;` and `#` after the
+  beginning of the line to mark the rest of a line as comment. This led to
+  confusion how to parse values containing those characters. Old EditorConfig
+  parsers may still allow inline comments.
+
 Terms
 -----
 
@@ -98,12 +122,6 @@ EditorConfig defines the following terms for parts of an EditorConfig file:
 - Section Name: the string between the beginning ``[`` and the ending ``]``.
 - Section: the lines starting from a Section Header until the beginning of
   the next Section Header or the end of the file.
-
-
-   The EditorConfig file format formerly allowed the use of `;` and `#` after the
-   beginning of the line to mark the rest of a line as comment. This led to
-   confusion how to parse values containing those characters. Old EditorConfig
-   parsers may still allow inline comments.
 
 Glob Expressions
 ================


### PR DESCRIPTION
It looks like the current wording still leads to too much confusion: https://github.com/editorconfig/specification/pull/29#discussion_r783382976

I therefore propose to remove the explaining addition about inline comments at all, in favor of a description of the former behavior of EditorConfig parsers.