### PR TITLE
Turn off syntax highlighting of text blocks

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -22,6 +22,7 @@
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 
+.. highlight:: text
 
 EditorConfig Specification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Our text blocks are not in a recognized language.  Since the colors are wrong, turn them off!

Before: 
![image](https://user-images.githubusercontent.com/10515894/198845669-03ad44a0-8741-4dfd-bbda-f7807d0adab5.png)

After:
![image](https://user-images.githubusercontent.com/10515894/198845694-108fbae9-c8ba-4ea6-970e-6a5139ee6843.png)
