### PR TITLE
Add indent_method property for nontrivial indentation methods

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -212,6 +212,10 @@ and the supported values associated with them:
        equals ``tab``, the ``indent_size`` shall be set to the tab size, which
        should be ``tab_width`` (if specified); else, the tab size set by the
        editor. The values are case insensitive.
+   * - ``indent_method``
+     - Set to ``smart_tabs`` or ``elastic_tabs`` to use a smart tabs respectively elastic
+       tabstops (when supported). The given tabstop method may override the ``indent_style``
+       or ``indent_size`` settings as required. 
    * - ``tab_width``
      - Set to a whole number defining the number of columns used to represent
        a tab character. This defaults to the value of ``indent_size`` and should


### PR DESCRIPTION
This PR aims to solve the requirement of https://github.com/editorconfig/editorconfig/issues/323 to add support for `smart_tabs`.

I propose to add a generic `indent_method` property to be able to
1. add support for non-trivial indentation methods
2. allow a backward compatible definition of indentation methods. Therefore the `indent_method` may override indent size and style if required.

I added two common (?) methods for the beginning: `smart_tabs` and `elastic_tabs`, the list may grow in the future.

I would prefer to also explain what `smart_tabs` and `elastic_tabs` refer to, for this it would be necessary to write a small explanation to avoid the risk any referenced website goes down.

What do you think?