### PR TITLE
Add spelling_language property

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ indent_size = 4
 indent_style = space
 end_of_line = lf
 max_line_length = 78
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: conf.py

--- a/conf.py
+++ b/conf.py
@@ -21,8 +21,8 @@ project = 'EditorConfig Specification'
 copyright = '2019--2020, EditorConfig Team'
 author = 'EditorConfig Team'
 
-version = '0.15.1'
-release = '0.15.1'
+version = '0.16.0'
+release = '0.16.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -186,7 +186,7 @@ files take precedence.
 Supported Pairs
 ===============
 
-.. versionchanged:: 0.15.1
+.. versionchanged:: 0.16
 
 EditorConfig file sections contain key-value pairs separated by an
 equal sign (``=``). With the exception of the ``root`` key, all pairs MUST be
@@ -224,6 +224,15 @@ and the supported values associated with them:
    * - ``charset``
      - Set to ``latin1``, ``utf-8``, ``utf-8-bom``, ``utf-16be`` or ``utf-16le`` to
        control the character set. Use of ``utf-8-bom`` is discouraged.
+   * - ``spelling_language``
+     - Sets the natural language that should be used for spell checking.
+       Only one language can be specified.  There is no default value.
+
+       The format is ``ss`` or ``ss-TT``, where ``ss`` is an `ISO 639`_
+       language code and ``TT`` is an `ISO 3166`_ territory identifier.
+
+       **Note:** This property does **not** specify the charset to be used.
+       The charset is in separate property ``charset``.
    * - ``trim_trailing_whitespace``
      - Set to ``true`` to remove all whitespace characters preceding newline
        characters in the file and ``false`` to ensure it doesn't.
@@ -277,6 +286,8 @@ numbers.  Those version numbers are independent of the version number of
 this specification.
 
 .. _core-tests repository: https://github.com/editorconfig/editorconfig-core-test
+.. _ISO 639: https://en.wikipedia.org/wiki/ISO_639
+.. _ISO 3166: https://en.wikipedia.org/wiki/ISO_3166
 .. _Python configparser Library: https://docs.python.org/3/library/configparser.html
 .. _Plugin Guidelines: https://github.com/editorconfig/editorconfig/wiki/Plugin-Guidelines
 .. _plugin-tests repository: https://github.com/editorconfig/editorconfig-plugin-tests


### PR DESCRIPTION
Resolves https://github.com/editorconfig/editorconfig/issues/315 .
To specify the natural language for which spelling should be checked.

**Open questions:**
- Should we use [RFC 5646](https://www.rfc-editor.org/rfc/rfc5646) tags instead of `xx_YY` ([ISO/IEC 15897](https://en.wikipedia.org/wiki/ISO/IEC_15897)) tags?  The RFC is freely available, which the ISO standard is not.
- If we do use ISO tags, should we restrict values at all?  E.g., only alpha-2?  Or expressly specify that alpha-3 is also accepted?