### PR TITLE
Clarify that curly braces only match literally without commas

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -155,7 +155,7 @@ special characters for wildcard matching:
    * - ``[!seq]``
      - any single character not in seq
    * - ``{s1,s2,s3}``
-     - any of the strings given (separated by commas, can be nested)
+     - any of the strings given (separated by commas, can be nested) (But ``{s1}`` only matches ``{s1}`` literally.)
    * - ``{num1..num2}``
      - any integer numbers between ``num1`` and ``num2``, where ``num1`` and ``num2``
        can be either positive or negative


### PR DESCRIPTION
This is a negligence when writing the spec. The tests have already been enforcing it since long time ago:

- https://github.com/editorconfig/editorconfig-core-test/blob/5ca0b296dc31124d0303895c163013450bd97958/glob/CMakeLists.txt#L129-L130
- https://github.com/editorconfig/editorconfig-core-test/blob/5ca0b296dc31124d0303895c163013450bd97958/glob/braces.in#L10-L11

Fix editorconfig/editorconfig-emacs#315