### PR TITLE
Clarify the effects of path separator

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -160,7 +160,7 @@ special characters for wildcard matching:
      - any integer numbers between ``num1`` and ``num2``, where ``num1`` and ``num2``
        can be either positive or negative
 
-If there is a path separator (``/``) at in the glob, then the glob is relative
+If the glob contains a path separator (a ``/`` not inside square brackets), then the glob is relative
 to the directory level of the particular `.editorconfig` file itself.
 Otherwise the pattern may also match at any level below the `.editorconfig`
 level. For example, ``*.c`` matches any file that ends with ``.c`` in the

--- a/index.rst
+++ b/index.rst
@@ -160,6 +160,13 @@ special characters for wildcard matching:
      - any integer numbers between ``num1`` and ``num2``, where ``num1`` and ``num2``
        can be either positive or negative
 
+If there is a path separator (``/``) at in the glob, then the glob is relative
+to the directory level of the particular `.editorconfig` file itself.
+Otherwise the pattern may also match at any level below the `.editorconfig`
+level. For example, ``*.c`` matches any file that ends with ``.c`` in the
+directory of ``.editorconfig``, but ``subdir/*.c`` only matches files that end
+with ``.c`` in the ``subdir`` directory in the directory of ``.editorconfig``.
+
 The backslash character (``\\``) can be used to escape a character so it is
 not interpreted as a special character.
 


### PR DESCRIPTION
This is consistent with the rules from `.gitignore`: <https://git-scm.com/docs/gitignore>

> If there is a separator at the beginning or middle (or both) of the
> pattern, then the pattern is relative to the directory level of the
> particular .gitignore file itself. Otherwise the pattern may also match
> at any level below the .gitignore level.

Since we intend to be consistent with `.gitignore`, this part of the spec has been unclear.

Fix editorconfig/editorconfig#509

<!-- readthedocs-preview editorconfig-specification start -->
----
📚 Documentation preview 📚: https://editorconfig-specification--49.org.readthedocs.build/

<!-- readthedocs-preview editorconfig-specification end -->