### PR TITLE
Set html_baseurl

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -18,13 +18,18 @@
 # -- Project information -----------------------------------------------------
 
 project = 'EditorConfig Specification'
-copyright = '2019--2020, EditorConfig Team'
+copyright = '2019--2024, EditorConfig Team'
 author = 'EditorConfig Team'
 
 version = '0.16.0'
 release = '0.16.0'
 
 # -- General configuration ---------------------------------------------------
+
+import os
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # The master document
 master_doc = 'index'


### PR DESCRIPTION
readthedoc will deprecate setting html_baseurl automatically soon soon. Now we set it explicitly in conf.py.

https://about.readthedocs.com/blog/2024/07/addons-by-default/#how-does-it-affect-my-projects