### PR TITLE
.editorconfig files MUST be utf-8, not just SHOULD.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,8 +21,8 @@ project = 'EditorConfig Specification'
 copyright = '2019--2024, EditorConfig Team'
 author = 'EditorConfig Team'
 
-version = '0.16.0'
-release = '0.16.0'
+version = '0.17.0'
+release = '0.17.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -73,6 +73,8 @@ EditorConfig organization.
 File Format
 ===========
 
+.. versionchanged:: 0.17.0
+
 EditorConfig files are in an INI-like file format.
 In an EditorConfig file, all beginning whitespace on each line is considered
 irrelevant. Each line must be one of the following:
@@ -94,7 +96,7 @@ irrelevant. Each line must be one of the following:
 
 Any line that is not one of the above is invalid.
 
-EditorConfig files should be UTF-8 encoded, with LF or CRLF line separators.
+EditorConfig files must be UTF-8 encoded, with LF or CRLF line separators.
 
 No inline comments
 ------------------


### PR DESCRIPTION
Fixes editorconfig/editorconfig#497.

This PR is silent on BOM.  We currently support BOM but don't specify it either way.  If we want to specify BOM, I think we should do so in a separate change.