### PR TITLE
spelling_language clarification: ss, TT are two-character codes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,8 +21,8 @@ project = 'EditorConfig Specification'
 copyright = '2019--2024, EditorConfig Team'
 author = 'EditorConfig Team'
 
-version = '0.16.0'
-release = '0.16.0'
+version = '0.16.1'
+release = '0.16.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -229,7 +229,9 @@ and the supported values associated with them:
        Only one language can be specified.  There is no default value.
 
        The format is ``ss`` or ``ss-TT``, where ``ss`` is an `ISO 639`_
-       language code and ``TT`` is an `ISO 3166`_ territory identifier.
+       two-letter language code and ``TT`` is an `ISO 3166`_ two-letter
+       territory identifier.  (Therefore ``spelling_language`` must be
+       either two or five characters long.)
 
        **Note:** This property does **not** specify the charset to be used.
        The charset is in separate property ``charset``.


### PR DESCRIPTION
We do not support the ISO numeric or three-letter codes.

Fixes #48

Reported by @gustaphe at <https://github.com/editorconfig/editorconfig-vim/pull/210#issuecomment-2043070775>.

<!-- readthedocs-preview editorconfig-specification start -->
----
📚 Documentation preview 📚: https://editorconfig-specification--54.org.readthedocs.build/

<!-- readthedocs-preview editorconfig-specification end -->