### PR TITLE
Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@
 
 name: Preview Generated Docs
 on:
-  pull_request:
+  pull_request_target:
     branches: ["master"]
 
 permissions:


### PR DESCRIPTION
Seems like pull_request_target grants more permission, and thus allow preview from a fork: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

Related: https://github.com/readthedocs/actions/issues/23

Fix #52