### PR TITLE
Rename readthedocs action name

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,6 @@
 # Preview the generated doc in pull requests.
 
-name: Preview Generated Docs
+name: readthedocs/actions
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Not sure if it can fix #52

<!-- readthedocs-preview editorconfig-specification start -->
----
📚 Documentation preview 📚: https://editorconfig-specification--57.org.readthedocs.build/

<!-- readthedocs-preview editorconfig-specification end -->