### PR TITLE
Clarified Glob Expressions example with no path separator

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -180,7 +180,8 @@ If the glob contains a path separator (a ``/`` not inside square brackets), then
 to the directory level of the particular `.editorconfig` file itself.
 Otherwise the pattern may also match at any level below the `.editorconfig`
 level. For example, ``*.c`` matches any file that ends with ``.c`` in the
-directory of ``.editorconfig``, but ``subdir/*.c`` only matches files that end
+directory of ``.editorconfig`` or any other directory below one that stores this ``.editorconfig``. 
+However, the glob ``subdir/*.c`` only matches files that end
 with ``.c`` in the ``subdir`` directory in the directory of ``.editorconfig``.
 
 As a corollary, a section name ending with ``/`` does not match any file.


### PR DESCRIPTION
There is an example in Glob Expressions where no file separator is involved for `*.c` in the spec. However, this example is a bit confusing, since it does not explicitly state that `*.c` does not only mean files in the current directory, where `.edictorconfig` is stored, but rather it applies to all files recursively below as well as the files in current directory.

So this PR just makes this explicit in the example. 

<!-- readthedocs-preview editorconfig-specification start -->
----
📚 Documentation preview 📚: https://editorconfig-specification--63.org.readthedocs.build/

<!-- readthedocs-preview editorconfig-specification end -->