### PR TITLE
docs(spec): disable backlinks in table of contents

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -30,6 +30,7 @@ EditorConfig Specification
 This is version |version| of this specification.
 
 .. contents:: Table of Contents
+  :backlinks: none
 
 Introduction (informative)
 ==========================


### PR DESCRIPTION
resolves #72 

<!-- readthedocs-preview editorconfig-specification start -->
----
📚 Documentation preview 📚: https://editorconfig-specification--73.org.readthedocs.build/

<!-- readthedocs-preview editorconfig-specification end -->